### PR TITLE
Fixed jpackage issue using joou for Java 9+

### DIFF
--- a/xar/pom.xml
+++ b/xar/pom.xml
@@ -51,13 +51,6 @@
             <version>${okio.version}</version>
         </dependency>
 
-        <!-- jOOU -->
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>joou-java-6</artifactId>
-            <version>${joou.version}</version>
-        </dependency>
-
         <!-- SLF4J -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -123,5 +116,39 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>UntilJava8</id>
+            <activation>
+              <jdk>[1.0, 1.9)</jdk>
+            </activation>
+            
+            <dependencies>
+                <!-- jOOU -->
+                <dependency>
+                    <groupId>org.jooq</groupId>
+                    <artifactId>joou-java-6</artifactId>
+                    <version>${joou.version}</version>
+                </dependency>
+            </dependencies>
+            
+        </profile>
+                <profile>
+            <id>AfterJava8</id>
+            <activation>
+              <jdk>[1.9,)</jdk>
+            </activation>
+            
+            <dependencies>
+                <!-- jOOU -->
+                <dependency>
+                    <groupId>org.jooq</groupId>
+                    <artifactId>joou</artifactId>
+                    <version>${joou.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Using jpackage lead to an error because there was a dependency to joou-java-6. By introducing two profiles this issue could be solved. The correct profile is activated based on the Java environment (defined through the JAVA_HOME environment variable). For Java 9 and later joou for Java 9 and later is used while for Java 8 and earlier joou-java-6 is used as dependency. Tested with Java 8 and Java 11